### PR TITLE
Updated README.md - small typo edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ type Action
     | Modify ID Counter.Action
 ```
 
-The `update` function is pretty similar to example 4 as well.
+The `update` function is pretty similar to example 3 as well.
 
 ```elm
 update : Action -> Model -> Model


### PR DESCRIPTION
Line 487 says "...similar to example 4..", but I think it should say "...similar to example 3...". Could confuse a newcomer.