### PR TITLE
Update [fancy] hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,4 +595,4 @@ If this is not clear, maybe I will write example 5 that shows this pattern in
 action. In the meantime, you can see examples like this in [the fancy version
 of the TodoMVC app written in Elm][fancy].
 
-[fancy]: https://github.com/evancz/elm-todomvc/blob/trim/Todo.elm
+[fancy]: https://github.com/evancz/elm-todomvc/blob/master/Todo.elm


### PR DESCRIPTION
Old link pointed to the trim branch, which is not updated to the 0.15 based architecture.