### PR TITLE
Fix dependencies for example 8

### DIFF
--- a/examples/8/elm-package.json
+++ b/examples/8/elm-package.json
@@ -8,11 +8,12 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "DanDanDan/Easing": "2.0.0 <= v < 3.0.0",
+        "Dandandan/Easing": "2.0.0 <= v < 3.0.0",
         "elm-lang/core": "3.0.0 <= v < 4.0.0",
         "evancz/elm-effects": "2.0.1 <= v < 3.0.0",
         "evancz/elm-html": "4.0.2 <= v < 5.0.0",
         "evancz/elm-http": "3.0.0 <= v < 4.0.0",
+        "evancz/elm-svg": "2.0.1 <= v < 3.0.0",
         "evancz/start-app": "2.0.2 <= v < 3.0.0"
     },
     "elm-version": "0.16.0 <= v < 0.17.0"


### PR DESCRIPTION
Dependencies in file elm-package.json for example 8 are broken - Dandandan is spelled incorrectly and elm-svg dependency is missing. This pull request fixes them.