### PR TITLE
Update example links: replace run locally by see code for more clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ This tutorial is all about this pattern and small variations and extensions.
 
 ## Example 1: A Counter
 
-**[demo](http://evancz.github.io/elm-architecture-tutorial/examples/1.html) / [run locally](examples/1/)**
+**[demo](http://evancz.github.io/elm-architecture-tutorial/examples/1.html) / [see code](examples/1/)**
 
 Our first example is a simple counter that can be incremented or decremented.
 
@@ -143,7 +143,7 @@ Notice we are not *performing* actions as they get sent back to our app. We are 
 
 ## Example 2: A Pair of Counters
 
-**[demo](http://evancz.github.io/elm-architecture-tutorial/examples/2.html) / [run locally](examples/2/)**
+**[demo](http://evancz.github.io/elm-architecture-tutorial/examples/2.html) / [see code](examples/2/)**
 
 In example 1 we created a basic counter, but how does that pattern scale when we want *two* counters? Can we keep things modular?
 
@@ -229,7 +229,7 @@ That is the whole thing. The cool thing is that we can keep nesting more and mor
 
 ## Example 3: A Dynamic List of Counters
 
-**[demo](http://evancz.github.io/elm-architecture-tutorial/examples/3.html) / [run locally](examples/3/)**
+**[demo](http://evancz.github.io/elm-architecture-tutorial/examples/3.html) / [see code](examples/3/)**
 
 A pair of counters is cool, but what about a list of counters where we can add and remove counters as we see fit? Can this pattern work for that too?
 
@@ -328,7 +328,7 @@ This ID trick can be used any time you want a dynamic number of subcomponents. C
 
 ## Example 4: A Fancier List of Counters
 
-**[demo](http://evancz.github.io/elm-architecture-tutorial/examples/4.html) / [run locally](examples/4/)**
+**[demo](http://evancz.github.io/elm-architecture-tutorial/examples/4.html) / [see code](examples/4/)**
 
 Okay, keeping things simple and modular on a dynamic list of counters is pretty cool, but instead of a general remove button, what if each counter had its own specific remove button? Surely *that* will mess things up!
 
@@ -451,7 +451,7 @@ At every level of nesting we can derive the specific `Context` needed for each s
 
 ## Example 5: Random GIF Viewer
 
-**[demo](http://evancz.github.io/elm-architecture-tutorial/examples/5.html) / [run locally](examples/5/)**
+**[demo](http://evancz.github.io/elm-architecture-tutorial/examples/5.html) / [see code](examples/5/)**
 
 So we have covered how to create infinitely nestable components, but what happens when we want to do an HTTP request from somewhere in there? Or talk to a database? This example starts using [the `elm-effects` package][fx] to create a simple component that fetches random gifs from giphy.com with the topic “funny cats”. 
 
@@ -588,7 +588,7 @@ I am going to try to explain exactly how that works, but it is not crucial to ge
 
 ## Example 6: Pair of random GIF viewers
 
-**[demo](http://evancz.github.io/elm-architecture-tutorial/examples/6.html) / [run locally](examples/6/)**
+**[demo](http://evancz.github.io/elm-architecture-tutorial/examples/6.html) / [see code](examples/6/)**
 
 Alright, effects can be done, but what about *nested* effects? Did you think about that?! This example reuses the exact code from the GIF viewer in example 5 to create a pair of independent GIF viewers.
 
@@ -660,7 +660,7 @@ In this case we not only use `Effects.map` to tag results appropriately, we also
 
 ## Example 7: List of random GIF viewers
 
-**[demo](http://evancz.github.io/elm-architecture-tutorial/examples/7.html) / [run locally](examples/7/)**
+**[demo](http://evancz.github.io/elm-architecture-tutorial/examples/7.html) / [see code](examples/7/)**
 
 This example lets you have a list of random GIF viewers where you can create the topics yourself. Again, we reuse the core `RandomGif` module exactly as is.
 
@@ -671,7 +671,7 @@ Please open an issue if this section should go into more detail about how things
 
 ## Example 8: Animation
 
-**[demo](http://evancz.github.io/elm-architecture-tutorial/examples/8.html) / [run locally](examples/8/)**
+**[demo](http://evancz.github.io/elm-architecture-tutorial/examples/8.html) / [see code](examples/8/)**
 
 Now we have seen components with tasks that can be nested in arbitrary ways, but how does it work for animation?
 


### PR DESCRIPTION
Relative to https://github.com/evancz/elm-architecture-tutorial/issues/39. 

Just replacing the 'run locally' by 'see code' for accessing to the codebase of each example, more clear for me :)