### PR TITLE
Https -> Http

### DIFF
--- a/examples/1/README.md
+++ b/examples/1/README.md
@@ -1,6 +1,6 @@
 ## Preview
 
-Click [here](https://evancz.github.io/elm-architecture-tutorial/examples/1) to see it running.
+Click [here](http://evancz.github.io/elm-architecture-tutorial/examples/1) to see it running.
 
 
 ## Run Locally

--- a/examples/2/README.md
+++ b/examples/2/README.md
@@ -1,6 +1,6 @@
 ## Preview
 
-Click [here](https://evancz.github.io/elm-architecture-tutorial/examples/2) to see it running.
+Click [here](http://evancz.github.io/elm-architecture-tutorial/examples/2) to see it running.
 
 
 ## Run Locally

--- a/examples/3/README.md
+++ b/examples/3/README.md
@@ -1,6 +1,6 @@
 ## Preview
 
-Click [here](https://evancz.github.io/elm-architecture-tutorial/examples/3) to see it running.
+Click [here](http://evancz.github.io/elm-architecture-tutorial/examples/3) to see it running.
 
 
 ## Run Locally

--- a/examples/4/README.md
+++ b/examples/4/README.md
@@ -1,6 +1,6 @@
 ## Preview
 
-Click [here](https://evancz.github.io/elm-architecture-tutorial/examples/4) to see it running.
+Click [here](http://evancz.github.io/elm-architecture-tutorial/examples/4) to see it running.
 
 
 ## Run Locally

--- a/examples/5/README.md
+++ b/examples/5/README.md
@@ -1,6 +1,6 @@
 ## Preview
 
-Click [here](https://evancz.github.io/elm-architecture-tutorial/examples/5) to see it running.
+Click [here](http://evancz.github.io/elm-architecture-tutorial/examples/5) to see it running.
 
 
 ## Run Locally

--- a/examples/6/README.md
+++ b/examples/6/README.md
@@ -1,6 +1,6 @@
 ## Preview
 
-Click [here](https://evancz.github.io/elm-architecture-tutorial/examples/6) to see it running.
+Click [here](http://evancz.github.io/elm-architecture-tutorial/examples/6) to see it running.
 
 
 ## Run Locally

--- a/examples/7/README.md
+++ b/examples/7/README.md
@@ -1,6 +1,6 @@
 ## Preview
 
-Click [here](https://evancz.github.io/elm-architecture-tutorial/examples/7) to see it running.
+Click [here](http://evancz.github.io/elm-architecture-tutorial/examples/7) to see it running.
 
 
 ## Run Locally

--- a/examples/8/README.md
+++ b/examples/8/README.md
@@ -1,6 +1,6 @@
 ## Preview
 
-Click [here](https://evancz.github.io/elm-architecture-tutorial/examples/8) to see it running.
+Click [here](http://evancz.github.io/elm-architecture-tutorial/examples/8) to see it running.
 
 
 ## Run Locally


### PR DESCRIPTION
The main `README.md` has example links as `http://` but the individual example `README.md` files have example links as `https://`. Unfortunately it looks like `https://` breaks the gif fetcher functionality, but it works find on `http://`. 

So the `https://` links in the example `README.md`s are moved to `http://`