### PR TITLE
Add a note about (=>) = (,)

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,6 +562,10 @@ getRandomGif topic =
 -- Finally we turn it into an `Effects` value that can be used in our
 -- `init` or `update` functions.
 
+-- By the way we are adding sugar syntax here. 
+-- Instead of `[("tag", topic)]` we can use `["tag" => topic]`.
+
+(=>) = (,)
 
 -- Given a topic, construct a URL for the giphy API.
 randomUrl : String -> String


### PR DESCRIPTION
In The Elm Architecture (in `README.md` and `examples/{5,6,7,8}`) we use sugar syntax e.g. `[ a => b ]`.  It would be nice to add a note about this (or remove such syntactic sugar from examples), because it does not work in REPL and may confuse beginners.