### PR TITLE
Using https instead of http on giphy.com

### DIFF
--- a/examples/5/RandomGif.elm
+++ b/examples/5/RandomGif.elm
@@ -89,7 +89,7 @@ getRandomGif topic =
 
 randomUrl : String -> String
 randomUrl topic =
-  Http.url "http://api.giphy.com/v1/gifs/random"
+  Http.url "https://api.giphy.com/v1/gifs/random"
     [ "api_key" => "dc6zaTOxFJmzC"
     , "tag" => topic
     ]

--- a/examples/6/RandomGif.elm
+++ b/examples/6/RandomGif.elm
@@ -89,7 +89,7 @@ getRandomGif topic =
 
 randomUrl : String -> String
 randomUrl topic =
-  Http.url "http://api.giphy.com/v1/gifs/random"
+  Http.url "https://api.giphy.com/v1/gifs/random"
     [ "api_key" => "dc6zaTOxFJmzC"
     , "tag" => topic
     ]

--- a/examples/7/RandomGif.elm
+++ b/examples/7/RandomGif.elm
@@ -89,7 +89,7 @@ getRandomGif topic =
 
 randomUrl : String -> String
 randomUrl topic =
-  Http.url "http://api.giphy.com/v1/gifs/random"
+  Http.url "https://api.giphy.com/v1/gifs/random"
     [ "api_key" => "dc6zaTOxFJmzC"
     , "tag" => topic
     ]


### PR DESCRIPTION
This removes the warning/error on mixed content. That arise when running the demos from the github/README.

```
Mixed Content: The page at 'https://evancz.github.io/elm-architecture-tutorial/examples/6.html' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint 'http://api.giphy.com/v1/gifs/random?api_key=dc6zaTOxFJmzC&tag=funny+cats'. This request has been blocked; the content must be served over HTTPS.(anonymous function) @ 6.html:7188
6.html:7188 Mixed Content: The page at 'https://evancz.github.io/elm-architecture-tutorial/examples/6.html' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint 'http://api.giphy.com/v1/gifs/random?api_key=dc6zaTOxFJmzC&tag=funny+dogs'. This request has been blocked; the content must be served over HTTPS.(anonymous function) @ 6.html:7188
```
