### PR TITLE
Don't need to expose everything (and don't need attributes)

### DIFF
--- a/examples/2/CounterPair.elm
+++ b/examples/2/CounterPair.elm
@@ -2,8 +2,7 @@ module CounterPair where
 
 import Counter
 import Html exposing (..)
-import Html.Attributes exposing (..)
-import Html.Events exposing (..)
+import Html.Events exposing (onClick)
 
 
 -- MODEL


### PR DESCRIPTION
we should only expose `onClick` and we don't need to `import Html.Attributes` at all in this module, right?