### PR TITLE
since arrow is mapped above, use it on the style

### DIFF
--- a/examples/7/RandomGifList.elm
+++ b/examples/7/RandomGifList.elm
@@ -105,11 +105,11 @@ elementView address (id, model) =
 inputStyle : Attribute
 inputStyle =
     style
-        [ ("width", "100%")
-        , ("height", "40px")
-        , ("padding", "10px 0")
-        , ("font-size", "2em")
-        , ("text-align", "center")
+        [ "width" => "100%"
+        , "height" => "40px"
+        , "padding" => "10px 0"
+        , "font-size" => "2em"
+        , "text-align" => "center"
         ]
 
 


### PR DESCRIPTION
since the arrow is mapped above, it may make sense to use it in the style
below, in order to not confuse people new to the language.