### PR TITLE
Fixes missing type annotation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,11 @@ This pattern is the essence of architecting Elm programs. Every example we see f
 Pretty much all Elm programs will have a small bit of code that drives the whole application. For each example in this tutorial, that code is broken out into `Main.elm`. For our counter example, the interesting code looks like this:
 
 ```elm
+import Html exposing (Html)
 import Counter exposing (update, view)
 import StartApp.Simple exposing (start)
 
+main : Signal Html
 main =
   start { model = 0, update = update, view = view }
 ```

--- a/examples/1/Main.elm
+++ b/examples/1/Main.elm
@@ -1,8 +1,8 @@
-
+import Html exposing (Html)
 import Counter exposing (update, view)
 import StartApp.Simple exposing (start)
 
-
+main : Signal Html
 main =
   start
     { model = 0


### PR DESCRIPTION
I saw the warning below when comiling with Elm Platform 0.16.0.  This PR removes the warning by importing Html, and adding the type annotation recommended by the Elm compiler.

```elm
-- missing type annotation -------------------------------------------- Main.elm

Top-level value `main` does not have a type annotation.

 6│>main =
 7│>  start
 8│>    { model = 0
 9│>    , update = update
10│>    , view = view
11│>    }

I inferred the type annotation so you can copy it into your code:

main : Signal Html
```