### PR TITLE
Change link to HTTP to avoid security warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Elm Architecture is a simple pattern for infinitely nestable components.
 
 This repo parallels [The Elm Architecture tutorial][arch], allowing you to follow along and compile things locally.
 
-[arch]: https://guide.elm-lang.org/architecture/index.html
+[arch]: http://guide.elm-lang.org/architecture/index.html
 
 
 ## Run The Examples


### PR DESCRIPTION
Hello,
I know I'm not the first one to notice this: it has been discussed on Slack.
But somehow, it looks like nobody had fixed it yet.