### PR TITLE
Clock Example: Fix hand

### DIFF
--- a/examples/6-clock.elm
+++ b/examples/6-clock.elm
@@ -62,10 +62,10 @@ view model =
       turns (Time.inMinutes model)
 
     handX =
-      toString (50 + 40 * cos angle)
+      toString (50 + 40 * sin angle)
 
     handY =
-      toString (50 + 40 * sin angle)
+      toString (50 - 40 * cos angle)
   in
     svg [ viewBox "0 0 100 100", width "300px" ]
       [ circle [ cx "50", cy "50", r "45", fill "#0B79CE" ] []


### PR DESCRIPTION
The ticking second hand was always 90° further round than it should have been. e.g. at 23:42:00 it would point at the 3 o'clock position rather than straight up.
