### PR TITLE
Use actual type instead of type variable

### DIFF
--- a/examples/3-form.elm
+++ b/examples/3-form.elm
@@ -65,7 +65,7 @@ view model =
     ]
 
 
-viewValidation : Model -> Html msg
+viewValidation : Model -> Html Msg
 viewValidation model =
   let
     (color, message) =


### PR DESCRIPTION
Use `Msg` instead of `msg` in the signature of `viewValidation`.

`msg` works because, I guess (extrapolating from my poor Haskell knowledge) is a type variable (`a` would work too). But maybe someone reading the tutorial may get confused about the change in the signature.