### PR TITLE
Fixed Markdown package (evancz/elm-markdown) dependency.

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -12,7 +12,8 @@
         "elm-lang/html": "1.0.0 <= v < 2.0.0",
         "elm-lang/svg": "1.0.0 <= v < 2.0.0",
         "elm-lang/websocket": "1.0.0 <= v < 2.0.0",
-        "evancz/elm-http": "3.0.1 <= v < 4.0.0"
+        "evancz/elm-http": "3.0.1 <= v < 4.0.0",
+        "evancz/elm-markdown": "3.0.0 <= v < 4.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }


### PR DESCRIPTION
New Radio button example, imports Markdown module, which is not specified on `elm-package.json`