### PR TITLE
Fix CORS error.

### DIFF
--- a/examples/5-http.elm
+++ b/examples/5-http.elm
@@ -88,7 +88,7 @@ getRandomGif : String -> Cmd Msg
 getRandomGif topic =
   let
     url =
-      "//api.giphy.com/v1/gifs/random?api_key=dc6zaTOxFJmzC&tag=" ++ topic
+      "https://api.giphy.com/v1/gifs/random?api_key=dc6zaTOxFJmzC&tag=" ++ topic
   in
     Task.perform FetchFail FetchSucceed (Http.get decodeGifUrl url)
 


### PR DESCRIPTION
Without the `https` prefix chrome throws the following error
```
5-http.elm.html:8390 XMLHttpRequest cannot load file://api.giphy.com/v1/gifs/random?api_key=dc6zaTOxFJmzC&tag=cats. Cross origin requests are only supported for protocol schemes: http, data, chrome, chrome-extension, https, chrome-extension-resource.
```