### PR TITLE
Remove unused `Attribute` module

### DIFF
--- a/examples/02-field.elm
+++ b/examples/02-field.elm
@@ -1,4 +1,4 @@
-import Html exposing (Html, Attribute, div, input, text)
+import Html exposing (Html, div, input, text)
 import Html.App as Html
 import Html.Attributes exposing (..)
 import Html.Events exposing (onInput)


### PR DESCRIPTION
Hi- I was recreating the tutorial to learn Elm and found that the `Attribute` module is unused in this example and am submitting a PR :) It was slightly confusing since I wasn't sure if it was used or not, but after removing it the example was still working.