### PR TITLE
Updating Websocket Link

### DIFF
--- a/examples/07-websockets.elm
+++ b/examples/07-websockets.elm
@@ -16,7 +16,7 @@ main =
 
 echoServer : String
 echoServer =
-  "ws://echo.websocket.org"
+  "wss://echo.websocket.org"
 
 
 


### PR DESCRIPTION
The current example for websockets uses an outdated Link ("ws://echo.websocket.org") which doesn't work and returns a 400 response. This link works though: "wss://echo.websocket.org".  

Just a one letter change fix.