### PR TITLE
Wrap form inputs in a span for compatibility with browser extensions

### DIFF
--- a/examples/03-form.elm
+++ b/examples/03-form.elm
@@ -67,7 +67,7 @@ view model =
 
 viewInput : String -> String -> String -> (String -> msg) -> Html msg
 viewInput t p v toMsg =
-  input [ type_ t, placeholder p, value v, onInput toMsg ] []
+  span [] [ input [ type_ t, placeholder p, value v, onInput toMsg ] [] ]
 
 
 viewValidation : Model -> Html msg


### PR DESCRIPTION
Problem:
The form example does not work with the 1Password browser extension in Chrome and Firefox. It may also be affected by other browsers / extensions.

Solution:
Wrap inputs in a span element. This is applied to the function that generates the input elements, which gives the fix a very small footprint.