### PR TITLE
Fix type annotations in form exercise

### DIFF
--- a/examples/03-form.elm
+++ b/examples/03-form.elm
@@ -65,12 +65,12 @@ view model =
     ]
 
 
-viewInput : String -> String -> String -> (String -> msg) -> Html msg
+viewInput : String -> String -> String -> (String -> msg) -> Html Msg
 viewInput t p v toMsg =
   input [ type_ t, placeholder p, value v, onInput toMsg ] []
 
 
-viewValidation : Model -> Html msg
+viewValidation : Model -> Html Msg
 viewValidation model =
   if model.password == model.passwordAgain then
     div [ style "color" "green" ] [ text "OK" ]


### PR DESCRIPTION
Both `viewInput` and `viewValidation` have an incorrect type annotation that prevents the example from working i.e. outputting `Html msg` instead of `Html Msg`.